### PR TITLE
Fix CI and add coverage reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
 name: Tests
 
-on:
-  pull_request:
+on: pull_request
 
 jobs:
   unit:
@@ -29,11 +28,10 @@ jobs:
       env:
         CI: true
 
-# TODO: Enable coverage report uploads once we open source the repo
-#     - name: Upload coverage to Codecov
-#       uses: codecov/codecov-action@v1.0.5
-#       with:
-#         token: ${{ secrets.CODECOV_TOKEN }}
-#         file: ./coverage/coverage-final.json
-#         flags: unit
-#         fail_ci_if_error: true
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1.0.5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage/coverage-final.json
+        flags: unit
+        fail_ci_if_error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: pull_request
+on: push
 
 jobs:
   unit:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,19 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
+        
+    - name: Cache node modules
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-node-modules
+      with:
+        # npm cache files are stored in `~/.npm` on Linux/macOS
+        path: ~/.npm
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
 
     - name: Install Dependencies
       run: npm install

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Ameelio Letters Mobile
 
-![Tests](https://github.com/AmeelioDev/letters-mobile/workflows/Tests/badge.svg)
+[![Tests](https://github.com/AmeelioDev/letters-mobile/workflows/Tests/badge.svg)](https://github.com/AmeelioDev/letters-mobile/actions?query=workflow%3ATests+branch%3A+master)
+[![codecov](https://codecov.io/gh/AmeelioDev/letters-mobile/branch/master/graph/badge.svg)](https://codecov.io/gh/AmeelioDev/letters-mobile)
 
 ![Ameelio Letters Logo](./src/assets/Ameelio_Logo.png)
 


### PR DESCRIPTION
## Description
Added coverage reporting and switched to running CI for all pushes. We're open source so now we can use codecov for free to show coverage reports in PRs and as a README status badge. CI was previously only running tests for pull requests but as a public repo we have unlimited GH Actions minutes so I suppose we may as well run for all pushes.

## Motivation and Context
The README status badge for our tests CI was just displaying the latest test to have run. This meant that if a PR was submitted with failing tests the repo status badge would show failing. We want the status badge to only show the status of master.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I played around with this workflow a bit on my own fork.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
