### PR TITLE
Fix coverage report uploads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,4 +50,4 @@ jobs:
       with:
         file: ./coverage/coverage-final.json
         flags: unit
-        fail_ci_if_error: true
+        fail_ci_if_error: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,6 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1.0.5
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage/coverage-final.json
         flags: unit
         fail_ci_if_error: true


### PR DESCRIPTION
## Description
Per the [codecov action docs](https://github.com/codecov/codecov-action) the codecov token isn't necessary for public repos.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
PRs created from forked repos are currently failing to upload the coverage reports. This is blocking PR merges. This makes sense because, for security reasons, forked repos don't have access to secrets stored by the main repo.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
